### PR TITLE
Add ROXAGENT role execution, to provide Client side for RHACS VM Scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scrible/kubeconfig-*
 .dockerconfigjson
 .DS_Store
 context/_build
+context/Containerfile

--- a/ansible-navigator.yaml
+++ b/ansible-navigator.yaml
@@ -24,6 +24,9 @@ ansible-navigator:
         - CONTROLLER_PASSWORD
         - CONTROLLER_USERNAME
         - CONTROLLER_VERIFY_SSL
+        - PODMAN_IMAGE_REGISTRY_HOST
+        - PODMAN_IMAGE_REGISTRY_USERNAME
+        - PODMAN_IMAGE_REGISTRY_PASSWORD
 #    image: quay.coe.muc.redhat.com/stormshift/automation-execution-environment:202502261102
     image: quay.coe.muc.redhat.com/stormshift/automation-execution-environment:202602021722
     pull:

--- a/cfg/secrets.yml.example
+++ b/cfg/secrets.yml.example
@@ -1,0 +1,30 @@
+# Copy to cfg/secrets.yml and fill in your values (cfg/secrets.yml is gitignored).
+#
+# Use the AAP gateway base URL only — do NOT append /api/controller.
+# The playbook sets AWXKIT_API_BASE_PATH=/api/controller/ automatically.
+
+aap_controller_host: "https://security-aap-aap.apps.ocp22.stormshift.coe.muc.redhat.com"
+aap_controller_username: admin
+aap_controller_password: "change-me"
+# aap_controller_validate_certs: false
+
+# Required job template credentials (names of existing AAP credentials):
+roxagent_aap_ssh_credential: ISAR-VM-SSH
+roxagent_aap_kubevirt_credential: ISAR-VM-Connect
+roxagent_aap_image_registry_credential: "Red Hat Content Delivery Network"
+
+# OpenShift Virtualization inventory filtering (source_vars → kubevirt plugin):
+#   label_selector — Kubernetes label selector (preferred; filters at sync time)
+#   namespaces     — optional list to limit sync to specific namespaces (omit to scan all)
+# host_filter — optional AWX regex on imported hostnames after sync (usually leave empty)
+roxagent_aap_inventory_source_label_selector: stormshift.coe.muc.redhat.com/roxagent=true
+# roxagent_aap_inventory_source_namespaces:
+#   - my-vm-namespace
+# roxagent_aap_inventory_source_host_filter: ''
+
+# Minutes between scheduled KubeVirt inventory syncs (batch job template inventory)
+# roxagent_aap_inventory_sync_interval_minutes: 15
+
+# Optional: create the image registry credential when running configure-roxagent-job-template.yaml
+# roxagent_registry_username: "9163d11a-...."
+# roxagent_registry_password: "...."

--- a/configure-roxagent-job-template.yaml
+++ b/configure-roxagent-job-template.yaml
@@ -1,0 +1,349 @@
+---
+# Register AAP job templates for RHACS roxagent provisioning.
+#
+# Batch:  Configure RHACS Roxagent — run against ISAR-vm-inventory (KubeVirt source).
+# Ad-hoc: Configure RHACS Roxagent - New VM — static inventory; target VM from extra_vars
+#         (survey, Launch API, or isar roxagent-trigger watcher).
+#
+# AAP on OpenShift uses the platform gateway API prefix /api/controller/.
+# Set only the gateway base URL in cfg/secrets.yml (no /api/controller suffix):
+#   aap_controller_host: https://security-aap-aap.apps.ocp22.stormshift.coe.muc.redhat.com
+#
+# Run:
+#   ansible-navigator run configure-roxagent-job-template.yaml -e @cfg/secrets.yml
+
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - awx.awx
+  environment:
+    AWXKIT_API_BASE_PATH: /api/controller/
+    CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX: /api/controller/
+    CONTROLLER_HOST: "{{ roxagent_aap_controller_host }}"
+    CONTROLLER_USERNAME: "{{ roxagent_aap_controller_username }}"
+    CONTROLLER_PASSWORD: "{{ roxagent_aap_controller_password }}"
+    CONTROLLER_VERIFY_SSL: "{{ roxagent_aap_controller_validate_certs | string | lower }}"
+  vars:
+    aap_podman_image_registry_credential_type: Podman Image Registry
+    roxagent_aap_project: stormshift-automation
+    roxagent_aap_project_scm_url: https://github.com/stormshift/automation.git
+    roxagent_aap_project_scm_branch: main
+    roxagent_aap_inventory: ISAR-vm-inventory
+    roxagent_aap_inventory_source_name: "{{ roxagent_aap_inventory }} - OpenShift Virtualization"
+    # host_filter: AWX post-import regex on inventory hostnames (optional).
+    roxagent_aap_inventory_source_host_filter: ""
+    # label_selector: passed to the KubeVirt plugin via source_vars (preferred).
+    # namespaces: optional list to limit sync scope; omit from source_vars when empty.
+    roxagent_aap_inventory_source_namespaces: []
+    roxagent_aap_inventory_source_label_selector: stormshift.coe.muc.redhat.com/roxagent=true
+    roxagent_aap_inventory_sync_schedule_name: "{{ roxagent_aap_inventory }} - KubeVirt sync"
+    roxagent_aap_inventory_sync_interval_minutes: 15
+    roxagent_aap_adhoc_inventory: Roxagent-adhoc
+    roxagent_aap_adhoc_host: adhoc-runner
+    # Do not set ansible_host to the VM pod IP; the playbook uses virtctl SSH.
+    # VM name/namespace are resolved in the roxagent role from inventory_hostname
+    # and namespace_* inventory groups (vmi_labels can omit name prefixes).
+    roxagent_aap_inventory_source_vars: >-
+      {{
+        {
+          'use_service': false,
+          'label_selector': roxagent_aap_inventory_source_label_selector,
+        }
+        | combine(
+            {'namespaces': roxagent_aap_inventory_source_namespaces}
+            if roxagent_aap_inventory_source_namespaces | length > 0
+            else {}
+          )
+      }}
+    roxagent_aap_organization: ISAR
+    roxagent_aap_execution_environment: stormshift-automation-execution-environment-202602021722
+    roxagent_aap_job_template_name: Configure RHACS Roxagent
+    roxagent_aap_adhoc_job_template_name: Configure RHACS Roxagent - New VM
+    roxagent_aap_ssh_credential: ""
+    roxagent_aap_kubevirt_credential: ""
+    roxagent_aap_image_registry_credential: ""
+    roxagent_aap_job_credentials:
+      - "{{ roxagent_aap_kubevirt_credential }}"
+      - "{{ roxagent_aap_ssh_credential }}"
+      - "{{ roxagent_aap_image_registry_credential }}"
+    roxagent_aap_controller_host: >-
+      {{
+        (
+          aap_controller_host
+          | default(lookup('env', 'CONTROLLER_HOST'), true)
+          | default('', true)
+        )
+        | regex_replace('/api/controller/?$', '')
+        | regex_replace('/$', '')
+      }}
+    roxagent_aap_controller_username: >-
+      {{ aap_controller_username | default(lookup('env', 'CONTROLLER_USERNAME'), true) | default('', true) }}
+    roxagent_aap_controller_password: >-
+      {{ aap_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD'), true) | default('', true) }}
+    roxagent_aap_controller_validate_certs: >-
+      {{ aap_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL', default='true')) | bool }}
+    roxagent_aap_rhacs_image: "{{ roxagent_aap_rhacs_image | default('registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:4.11.0') }}"
+    roxagent_aap_adhoc_survey_spec:
+      name: ""
+      description: Target KubeVirt VM for roxagent install (virtctl SSH from AAP).
+      spec:
+        - question_name: VM namespace
+          question_description: OpenShift project where the VM runs.
+          variable: roxagent_kubevirt_namespace
+          type: text
+          required: true
+        - question_name: VM name
+          question_description: KubeVirt VirtualMachine name.
+          variable: roxagent_kubevirt_vm_name
+          type: text
+          required: true
+        - question_name: SSH user
+          question_description: Guest SSH user for virtctl port-forward.
+          variable: roxagent_ansible_user
+          type: text
+          required: true
+          default: cloud-user
+
+  tasks:
+    - name: Fail when controller connection settings are incomplete
+      ansible.builtin.fail:
+        msg: >-
+          Set aap_controller_host, aap_controller_username, and aap_controller_password
+          in cfg/secrets.yml or export CONTROLLER_HOST, CONTROLLER_USERNAME, and
+          CONTROLLER_PASSWORD. Use the gateway base URL only (no /api/controller suffix).
+      when:
+        - roxagent_aap_controller_host | length == 0
+          or roxagent_aap_controller_username | length == 0
+          or roxagent_aap_controller_password | length == 0
+
+    - name: Fail when required job template credentials are not configured
+      ansible.builtin.fail:
+        msg: >-
+          Set roxagent_aap_ssh_credential, roxagent_aap_kubevirt_credential, and
+          roxagent_aap_image_registry_credential in cfg/secrets.yml. Each value must
+          be the name of an existing AAP credential (SSH, OpenShift/Kubernetes API,
+          and Podman Image Registry types respectively).
+      when:
+        - roxagent_aap_ssh_credential | length == 0
+          or roxagent_aap_kubevirt_credential | length == 0
+          or roxagent_aap_image_registry_credential | length == 0
+
+    - name: Show resolved AAP controller connection (debug)
+      ansible.builtin.debug:
+        msg:
+          controller_host: "{{ roxagent_aap_controller_host }}"
+          api_base_path: "{{ lookup('env', 'AWXKIT_API_BASE_PATH') }}"
+          controller_username: "{{ roxagent_aap_controller_username }}"
+          validate_certs: "{{ roxagent_aap_controller_validate_certs }}"
+          job_credentials: "{{ roxagent_aap_job_credentials }}"
+
+    - name: Ensure organization exists
+      awx.awx.organization:
+        name: "{{ roxagent_aap_organization }}"
+        description: "{{ roxagent_aap_organization }} OCP-V virtual machines and automation"
+        state: present
+
+    - name: Ensure VM inventory exists
+      awx.awx.inventory:
+        name: "{{ roxagent_aap_inventory }}"
+        organization: "{{ roxagent_aap_organization }}"
+        description: >-
+          RHEL VMs on {{ roxagent_aap_organization }} OCP-V for RHACS roxagent batch runs.
+        state: present
+
+    - name: Ensure OpenShift Virtualization inventory source exists
+      awx.awx.inventory_source:
+        name: "{{ roxagent_aap_inventory_source_name }}"
+        inventory: "{{ roxagent_aap_inventory }}"
+        organization: "{{ roxagent_aap_organization }}"
+        source: openshift_virtualization
+        credential: "{{ roxagent_aap_kubevirt_credential }}"
+        host_filter: "{{ roxagent_aap_inventory_source_host_filter }}"
+        source_vars: "{{ roxagent_aap_inventory_source_vars }}"
+        update_on_launch: false
+        overwrite: true
+        state: present
+
+    - name: Ensure periodic KubeVirt inventory sync schedule exists
+      awx.awx.schedule:
+        name: "{{ roxagent_aap_inventory_sync_schedule_name }}"
+        state: present
+        enabled: true
+        unified_job_template: "{{ roxagent_aap_inventory_source_name }}"
+        rrule: >-
+          DTSTART:20260101T000000Z RRULE:FREQ=MINUTELY;INTERVAL={{
+            roxagent_aap_inventory_sync_interval_minutes | int }}
+
+    - name: Ensure ad-hoc inventory exists
+      awx.awx.inventory:
+        name: "{{ roxagent_aap_adhoc_inventory }}"
+        organization: "{{ roxagent_aap_organization }}"
+        description: >-
+          Placeholder inventory for ad-hoc roxagent installs. The real VM target is
+          passed via job extra_vars (roxagent_kubevirt_namespace / roxagent_kubevirt_vm_name).
+        state: present
+
+    - name: Ensure ad-hoc placeholder host exists
+      awx.awx.host:
+        name: "{{ roxagent_aap_adhoc_host }}"
+        inventory: "{{ roxagent_aap_adhoc_inventory }}"
+        enabled: true
+        state: present
+
+    - name: Ensure automation project exists
+      awx.awx.project:
+        name: "{{ roxagent_aap_project }}"
+        organization: "{{ roxagent_aap_organization }}"
+        description: >-
+          StormShift automation playbooks for {{ roxagent_aap_organization }} VMs.
+        scm_type: git
+        scm_url: "{{ roxagent_aap_project_scm_url }}"
+        scm_branch: "{{ roxagent_aap_project_scm_branch }}"
+        scm_update_on_launch: true
+        scm_update_cache_timeout: 60
+        state: present
+
+    - name: Ensure Podman Image Registry credential type exists
+      awx.awx.credential_type:
+        name: "{{ aap_podman_image_registry_credential_type }}"
+        description: >-
+          Injects container registry credentials into playbooks via
+          PODMAN_IMAGE_REGISTRY_* environment variables. Use instead of the managed
+          Container Registry type when credentials must reach the playbook.
+        kind: cloud
+        inputs:
+          fields:
+            - id: host
+              type: string
+              label: Authentication URL
+              default: registry.redhat.io
+            - id: username
+              type: string
+              label: Username
+            - id: password
+              type: string
+              label: Password or Token
+              secret: true
+            - id: verify_ssl
+              type: boolean
+              label: Verify SSL
+              default: true
+          required:
+            - host
+            - username
+            - password
+        injectors:
+          env:
+            PODMAN_IMAGE_REGISTRY_HOST: "{{ '{{' }} host {{ '}}' }}"
+            PODMAN_IMAGE_REGISTRY_USERNAME: "{{ '{{' }} username {{ '}}' }}"
+            PODMAN_IMAGE_REGISTRY_PASSWORD: "{{ '{{' }} password {{ '}}' }}"
+        state: present
+
+    - name: Ensure image registry credential exists in AAP
+      awx.awx.credential:
+        name: "{{ roxagent_aap_image_registry_credential }}"
+        organization: "{{ roxagent_aap_organization }}"
+        credential_type: "{{ aap_podman_image_registry_credential_type }}"
+        description: Container registry pull credentials for podman jobs.
+        inputs:
+          host: "{{ roxagent_registry_host | default('registry.redhat.io') }}"
+          username: "{{ roxagent_registry_username }}"
+          password: "{{ roxagent_registry_password }}"
+          verify_ssl: true
+        state: present
+      when:
+        - roxagent_registry_username | default('') | length > 0
+        - roxagent_registry_password | default('') | length > 0
+      no_log: true
+
+    - name: Fetch image registry credential metadata from AAP
+      ansible.builtin.uri:
+        url: >-
+          {{ roxagent_aap_controller_host }}/api/controller/v2/credentials/?name__iexact={{
+            roxagent_aap_image_registry_credential | urlencode }}&organization__name={{
+            roxagent_aap_organization | urlencode }}
+        url_username: "{{ roxagent_aap_controller_username }}"
+        url_password: "{{ roxagent_aap_controller_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ roxagent_aap_controller_validate_certs }}"
+        return_content: true
+      register: _roxagent_image_registry_cred_lookup
+
+    - name: Fail when image registry credential is missing in AAP
+      ansible.builtin.fail:
+        msg: >-
+          Credential "{{ roxagent_aap_image_registry_credential }}" was not found in
+          organization "{{ roxagent_aap_organization }}". Create it with type
+          "{{ aap_podman_image_registry_credential_type }}", or set
+          roxagent_registry_username/password in cfg/secrets.yml and re-run this
+          playbook to create it automatically.
+      when: _roxagent_image_registry_cred_lookup.json.count | default(0) == 0
+
+    - name: Fail when image registry credential uses managed Container Registry type
+      ansible.builtin.fail:
+        msg: >-
+          Credential "{{ roxagent_aap_image_registry_credential }}" is the managed
+          Container Registry type (kind registry). AAP cannot attach that to job
+          templates and it does not inject into playbooks. Delete it, then recreate
+          it with credential type "{{ aap_podman_image_registry_credential_type }}"
+          or set roxagent_registry_username/password in cfg/secrets.yml and re-run
+          this playbook.
+      when:
+        - _roxagent_image_registry_cred_lookup.json.results[0].kind == 'registry'
+
+    - name: Create batch roxagent job template
+      awx.awx.job_template:
+        name: "{{ roxagent_aap_job_template_name }}"
+        description: >-
+          Install/update RHACS roxagent on RHEL VMs from KubeVirt inventory.
+          Managed by configure-roxagent-job-template.yaml. Launch from AAP to run
+          against all or a subset of inventory hosts.
+        job_type: run
+        organization: "{{ roxagent_aap_organization }}"
+        inventory: "{{ roxagent_aap_inventory }}"
+        project: "{{ roxagent_aap_project }}"
+        playbook: configure-roxagent.yaml
+        execution_environment: "{{ roxagent_aap_execution_environment }}"
+        credentials: "{{ roxagent_aap_job_credentials }}"
+        state: present
+        allow_simultaneous: true
+        ask_variables_on_launch: true
+        ask_limit_on_launch: true
+        host_config_key: ""
+        extra_vars:
+          roxagent_rhacs_image: "{{ roxagent_aap_rhacs_image }}"
+          roxagent_virtctl_ssh: true
+
+    - name: Create ad-hoc roxagent job template
+      awx.awx.job_template:
+        name: "{{ roxagent_aap_adhoc_job_template_name }}"
+        description: >-
+          Install RHACS roxagent on a single newly deployed VM. Target VM is set via
+          survey extra_vars. Launched automatically by the isar roxagent-trigger watcher
+          or manually from the AAP UI.
+        job_type: run
+        organization: "{{ roxagent_aap_organization }}"
+        inventory: "{{ roxagent_aap_adhoc_inventory }}"
+        project: "{{ roxagent_aap_project }}"
+        playbook: configure-roxagent.yaml
+        execution_environment: "{{ roxagent_aap_execution_environment }}"
+        credentials: "{{ roxagent_aap_job_credentials }}"
+        state: present
+        allow_simultaneous: true
+        limit: "{{ roxagent_aap_adhoc_host }}"
+        survey_enabled: true
+        survey_spec: "{{ roxagent_aap_adhoc_survey_spec }}"
+        extra_vars:
+          roxagent_rhacs_image: "{{ roxagent_aap_rhacs_image }}"
+          roxagent_virtctl_ssh: true
+
+    - name: Show job template summary
+      ansible.builtin.debug:
+        msg:
+          batch_job_template: "{{ roxagent_aap_job_template_name }}"
+          adhoc_job_template: "{{ roxagent_aap_adhoc_job_template_name }}"
+          inventory_sync_schedule: "{{ roxagent_aap_inventory_sync_schedule_name }}"
+          note: >-
+            Deploy isar-apps/ocp-v/roxagent-trigger on isar for automatic ad-hoc launches.
+            Create secret roxagent-trigger-aap with AAP credentials before starting the watcher.

--- a/configure-roxagent.yaml
+++ b/configure-roxagent.yaml
@@ -1,0 +1,38 @@
+---
+# Configure RHACS roxagent on RHEL VMs via the roxagent Ansible role.
+#
+# Batch (AAP job template "Configure RHACS Roxagent"):
+#   Launch against ISAR-vm-inventory; optionally set limit to subset of hosts.
+#
+# Ad-hoc (AAP job template "Configure RHACS Roxagent - New VM"):
+#   Survey / Launch API extra_vars: roxagent_kubevirt_namespace, roxagent_kubevirt_vm_name,
+#   roxagent_ansible_user (and optionally roxagent_target_host). Triggered by isar
+#   roxagent-trigger watcher or manual launch.
+#
+# Manual ansible-playbook:
+#   ansible-playbook configure-roxagent.yaml -l my-rhel-vm
+#
+# Registry auth: attach an AAP credential of type "Podman Image Registry" to the job template.
+#
+# SSH to pod-network VMs uses virtctl port-forward (see roxagent_virtctl_ssh in
+# sluetze.roxagent defaults). Attach the OpenShift/Kubernetes credential
+# used for the inventory source (for example ISAR-VM-Connect) to the job template.
+
+- name: Configure roxagent
+  hosts: "{{ roxagent_play_hosts | default('all') }}"
+  become: true
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ roxagent_kubeconfig_path | default('/runner/.kube/config') }}"
+  pre_tasks:
+    - name: Configure KubeVirt SSH connection
+      ansible.builtin.include_role:
+        name: sluetze.roxagent
+        tasks_from: set-kubevirt-connection.yml
+      when: roxagent_virtctl_ssh | default(true) | bool
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
+  roles:
+    - sluetze.roxagent

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -17,6 +17,9 @@ additional_build_steps:
     - RUN curl https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
           -o /etc/pki/ca-trust/source/anchors/RedHat_Current-IT-Root-CAs.pem &&
           update-ca-trust
+    - RUN curl -fsSL -o /usr/local/bin/virtctl
+          https://github.com/kubevirt/kubevirt/releases/download/v1.8.4/virtctl-v1.8.4-linux-amd64 &&
+          chmod +x /usr/local/bin/virtctl
 
 dependencies:
   ansible_core:
@@ -27,7 +30,7 @@ dependencies:
     python:
       - systemd-python
   python:
-    - ovirt-engine-sdk-python 
+    - ovirt-engine-sdk-python
     - six
   system:
     - nmstate
@@ -38,8 +41,11 @@ dependencies:
     - python3-wheel        # Fixes the 'legacy setup.py' warning
     - python3-setuptools   # Standardizes the build environment
     - libxml2-devel
-    - libcurl-devel 
+    - libcurl-devel
   galaxy:
+    roles:
+      - name: sluetze.roxagent
+        version: v0.1.0
     collections:
 # ToDo: add version numbers!
       - name: community.general
@@ -49,6 +55,7 @@ dependencies:
       - name: ansible.posix
       - name: community.crypto
       - name: kubevirt.core
+      - name: containers.podman
 
       - name: community.libvirt
         src: git+https://github.com/ansible-collections/community.libvirt


### PR DESCRIPTION
Together with https://github.com/stormshift/clusters/pull/37, this provides an automation to deploy roxagent on VMs that are labeled with stormshift.coe.muc.redhat.com/roxagent: 'true'

### IMPORTANT
currently there are multiple defaults defined for the security-aap, an AAP instance that I used for development. I can modify them if wanted to default to the ISAR AAP, which should be the goal.

This Role also requires a credential to be defined with access to VMs to fill the inventory 

```yaml
# Cluster access for AAP: VM inventory enumeration and virtctl SSH port-forward.
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: sluetzen-vm-vuln-demo-kubevirt-aap-vm-enum
rules:
  - apiGroups:
      - kubevirt.io
    resources:
      - virtualmachines
      - virtualmachineinstances
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - subresources.kubevirt.io
    resources:
      - virtualmachines/portforward
      - virtualmachineinstances/portforward
    verbs:
      - get
  - apiGroups:
      - ""
    resources:
      - namespaces
      - services
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - project.openshift.io
    resources:
      - projects
    verbs:
      - get
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: sluetzen-vm-vuln-demo-kubevirt-aap-vm-enum
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: sluetzen-vm-vuln-demo-kubevirt-aap-vm-enum
subjects:
  - kind: ServiceAccount
    name: sluetzen-vm-vuln-demo-kubevirt-aap
    namespace: sluetzen-vm-vuln-demo

```

## Summary

Adds automation to install RHACS roxagent on RHEL VMs running on OpenShift Virtualization (KubeVirt), using the external Galaxy role [`sluetze.roxagent`](https://galaxy.ansible.com/sluetze/roxagent) (v0.1.0).

- **Execution environment** — installs `virtctl` for SSH port-forwarding to pod-network VMs, adds `sluetze.roxagent` and `containers.podman`
- **`configure-roxagent.yaml`** — playbook for batch and ad-hoc roxagent installs via virtctl SSH
- **`configure-roxagent-job-template.yaml`** — provisions AAP resources: organization, KubeVirt inventory source (label-filtered), batch + ad-hoc job templates, Podman Image Registry credential type
- **`cfg/secrets.yml.example`** — documents required AAP controller and credential settings for local runs
- **ansible-navigator** — passes `PODMAN_IMAGE_REGISTRY_*` env vars for registry auth during local testing

### Job-Templates

Two AAP job templates cover the two deployment paths:

| Job template | Inventory | Use case |
|---|---|---|
| **Configure RHACS Roxagent** | `ISAR-vm-inventory` (KubeVirt source, label `stormshift.coe.muc.redhat.com/roxagent=true`) | Batch install/update on all matching VMs |
| **Configure RHACS Roxagent - New VM** | Static `Roxagent-adhoc` placeholder | Single VM via survey extra_vars; triggered by `roxagent-trigger` watcher or manual launch |

SSH to VMs on pod networking uses `virtctl ssh` port-forwarding (configured by the role's `set-kubevirt-connection.yml` pre-task). Registry credentials are injected via a custom AAP credential type **Podman Image Registry** that sets `PODMAN_IMAGE_REGISTRY_*` environment variables.


## Testing / Implementation

- [x] Rebuild execution environment from updated `execution-environment.yml` and verify `virtctl` and `sluetze.roxagent` role are present
- [ ] Copy `cfg/secrets.yml.example` → `cfg/secrets.yml`, fill in AAP credentials for ISAR AAP
- [ ] Run `ansible-navigator run configure-roxagent-job-template.yaml -e @cfg/secrets.yml` against SAR AAP
- [ ] Verify AAP resources created: organization, inventory, KubeVirt source, sync schedule, both job templates, Podman Image Registry credential type
- [ ] Update Inventory
- [ ] Deploy a test VM from a vuln-scan template (with `rhsm-cloud-init` secret and roxagent label)
- [ ] Launch **Configure RHACS Roxagent - New VM** ad-hoc job with survey vars (`roxagent_kubevirt_namespace`, `roxagent_kubevirt_vm_name`, `roxagent_ansible_user`)
- [ ] Confirm roxagent container is running on the VM and appears in RHACS Central
- [ ] Launch batch job **Configure RHACS Roxagent** with `--limit` on a subset of inventory hosts
